### PR TITLE
Setting docker-compose version to 3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 volumes:
   orderer.nomad.com:


### PR DESCRIPTION
New docker-compose version requires a higher version in the compose `.yaml`