### PR TITLE
Changed "CADB-dtag", "CADB-tmus" to "cadb-dtag", "cadb-tmus"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -259,8 +259,8 @@ services:
     networks:
       - nomad
 
-  CADB-dtag:
-    container_name: CADB-dtag
+  cadb-dtag:
+    container_name: cadb-dtag
     image: mongo:${MONGO_VERSION}
     restart: always
     environment:
@@ -282,12 +282,12 @@ services:
     restart: always
     environment:
       - LOG_LEVEL=${DTAG_LOG_LEVEL}
-      - DB_URL=mongodb://${DTAG_MONGO_USER}:${DTAG_MONGO_USERPW}@CADB-dtag:27017/commondb?authSource=commondb
+      - DB_URL=mongodb://${DTAG_MONGO_USER}:${DTAG_MONGO_USERPW}@cadb-dtag:27017/commondb?authSource=commondb
       - BLOCKCHAIN_ADAPTER_URL=http://blockchain-adapter-dtag:${DTAG_BLOCKCHAIN_ADAPTER_PORT}
       - 'BLOCKCHAIN_ADAPTER_WEBHOOK_EVENTS=["STORE:DOCUMENTHASH"]'
       - SELF_HOST=http://common-adapter-dtag:3000
     depends_on:
-      - CADB-dtag
+      - cadb-dtag
     ports:
       - ${DTAG_COMMON_ADAPTER_PORT}:3000
     networks:
@@ -478,8 +478,8 @@ services:
     networks:
       - nomad
 
-  CADB-tmus:
-    container_name: CADB-tmus
+  cadb-tmus:
+    container_name: cadb-tmus
     image: mongo:${MONGO_VERSION}
     restart: always
     environment:
@@ -501,12 +501,12 @@ services:
     restart: always
     environment:
       - LOG_LEVEL=${TMUS_LOG_LEVEL}
-      - DB_URL=mongodb://${TMUS_MONGO_USER}:${TMUS_MONGO_USERPW}@CADB-tmus:27017/commondb?authSource=commondb
+      - DB_URL=mongodb://${TMUS_MONGO_USER}:${TMUS_MONGO_USERPW}@cadb-tmus:27017/commondb?authSource=commondb
       - BLOCKCHAIN_ADAPTER_URL=http://blockchain-adapter-tmus:${TMUS_BLOCKCHAIN_ADAPTER_PORT}
       - 'BLOCKCHAIN_ADAPTER_WEBHOOK_EVENTS=["STORE:DOCUMENTHASH"]'
       - SELF_HOST=http://common-adapter-tmus:3000
     depends_on:
-      - CADB-tmus
+      - cadb-tmus
     ports:
       - ${TMUS_COMMON_ADAPTER_PORT}:3000
     networks:


### PR DESCRIPTION
Using uppercase in service and container name produces the following error message on mac os x

`{"message":"[DbUtils::startAndMaintainDbConnection] Could not connect to DB for 30000 ms. DB Connection = { url: 'mongodb://user:userpw@CADB-dtag:27017/commondb?authSource=commondb', createConnectionTimeout: '30000', heartbeatFrequency: '5000', poolSize: '10' }","level":"error","service":"user-service","timestamp":"2020-12-02T14:06:42.408Z“}`

Changing "CADB-dtag" to "cadb-dtag" fixes the problem.