### PR TITLE
core: update readme requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 * Docker & Docker-Compose
-* Linux or MAC OS X
+* Linux
 * OpenSSL 1.1.1
 
 ## Installation


### PR DESCRIPTION
removed mac from requirements. dev setup only runs on x86, no support for apple silicon (arm) at the moment